### PR TITLE
Add `aliasDivider` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ When rendered to HTML, we get:
 
 * `options.wikiLinkClassName`: a class name that is attached to any rendered wiki links. Defaults to `"internal"`.
 * `options.newClassName`: a class name that is attached to any rendered wiki links that do not exist. Defaults to `"new"`.
+* `options.aliasDivider`: a string for `aliased pages`.
 
 #### Aliasing pages
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remark-wiki-link",
   "description": "Parse and render wiki-style links",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "keywords": [
     "remark",
     "remark-plugin",

--- a/src/index.js
+++ b/src/index.js
@@ -93,7 +93,7 @@ function wikiLinkPlugin(opts = {}) {
     if (visitors) {
       visitors.wikiLink = function (node) {
         if (node.data.alias != node.value) {
-          return `[[${node.value}:${node.data.alias}]]`
+          return `[[${node.value}${aliasDivider}${node.data.alias}]]`
         }
         return `[[${node.value}]]`
       }

--- a/src/index.js
+++ b/src/index.js
@@ -14,13 +14,14 @@ function wikiLinkPlugin(opts = {}) {
   let wikiLinkClassName = opts.wikiLinkClassName || 'internal';
   let defaultHrefTemplate = (permalink) => `#/page/${permalink}`
   let hrefTemplate = opts.hrefTemplate || defaultHrefTemplate
+  let aliasDivider = opts.aliasDivider || ":";
 
   function isAlias(pageTitle) {
-    return pageTitle.indexOf(':') !== -1;
+    return pageTitle.indexOf(aliasDivider) !== -1;
   }
 
   function parseAliasLink(pageTitle) {
-    var [name, displayName] = pageTitle.split(':')
+    var [name, displayName] = pageTitle.split(aliasDivider);
     return { name, displayName }
   }
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -70,6 +70,29 @@ describe("remark-wiki-link", () => {
     })
   });
 
+  it("handles wiki alias links with custom divider", () => {
+    let processor = unified()
+      .use(markdown)
+      .use(wikiLinkPlugin, {
+        permalinks: [],
+        aliasDivider: "|"
+      });
+
+    var ast = processor.parse("[[Real Page|Page Alias]]");
+    ast = processor.runSync(ast);
+
+    visit(ast, "wikiLink", node => {
+      assert.equal(node.data.exists, false);
+      assert.equal(node.data.permalink, "real_page");
+      assert.equal(node.data.hName, "a");
+      assert.equal(node.data.alias, "Page Alias");
+      assert.equal(node.value, "Real Page");
+      assert.equal(node.data.hProperties.className, "internal new");
+      assert.equal(node.data.hProperties.href, "#/page/real_page");
+      assert.equal(node.data.hChildren[0].value, "Page Alias");
+    });
+  });
+
   it("stringifies wiki links", () => {
     let processor = unified()
         .use(markdown, { gfm: true, footnotes: true, yaml: true })


### PR DESCRIPTION
with `aliasDivider` option, you can use `[[link|show text]]` instead of `[[link:show text]]`.