### PR TITLE
Handle open link with partial alias

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-wiki-link",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1896,6 +1896,12 @@
       "dev": true,
       "optional": true
     },
+    "boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2320,6 +2326,12 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true,
       "optional": true
+    },
+    "css-selector-parser": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.4.1.tgz",
+      "integrity": "sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -3989,15 +4001,24 @@
       }
     },
     "mdast-util-from-markdown": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.0.tgz",
-      "integrity": "sha512-x9b9ekG2IfeqHSUPhn4+o8SeXqual0/ZHzzugV/cC21L6s1KyKAwIHKBJ1NN9ZstIlY8YAefELRSWfJMby4a9Q==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.4.tgz",
+      "integrity": "sha512-jj891B5pV2r63n2kBTFh8cRI2uR9LQHsXG1zSDqfhXkIlDzrTcIlbB5+5aaYEkl8vOPIOPLf8VT7Ere1wWTMdw==",
       "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
-        "mdast-util-to-string": "^1.0.0",
-        "micromark": "~2.10.0",
-        "parse-entities": "^2.0.0"
+        "mdast-util-to-string": "^2.0.0",
+        "micromark": "~2.11.0",
+        "parse-entities": "^2.0.0",
+        "unist-util-stringify-position": "^2.0.0"
+      },
+      "dependencies": {
+        "mdast-util-to-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+          "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+          "dev": true
+        }
       }
     },
     "mdast-util-to-hast": {
@@ -4095,9 +4116,9 @@
       "dev": true
     },
     "micromark": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.10.1.tgz",
-      "integrity": "sha512-fUuVF8sC1X7wsCS29SYQ2ZfIZYbTymp0EYr6sab3idFjigFFjGa5UwoniPlV9tAgntjuapW1t9U+S0yDYeGKHQ==",
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.2.tgz",
+      "integrity": "sha512-IXuP76p2uj8uMg4FQc1cRE7lPCLsfAXuEfdjtdO55VRiFO1asrCSQ5g43NmPqFtRwzEnEhafRVzn2jg0UiKArQ==",
       "dev": true,
       "requires": {
         "debug": "^4.0.0",
@@ -4105,9 +4126,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -4122,9 +4143,9 @@
       }
     },
     "micromark-extension-wiki-link": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/micromark-extension-wiki-link/-/micromark-extension-wiki-link-0.0.3.tgz",
-      "integrity": "sha512-6QRRdvmpOkI+gDjmMZ2JU41XzL71qM7CZDbfFI0q5Po9svl4jpEq/ozEOs1cdJmjW6UO3yKRdLTLCXZ2LjM/jg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/micromark-extension-wiki-link/-/micromark-extension-wiki-link-0.0.4.tgz",
+      "integrity": "sha512-dJc8AfnoU8BHkN+7fWZvIS20SMsMS1ZlxQUn6We67MqeKbOiEDZV5eEvCpwqGBijbJbxX3Kxz879L4K9HIiOvw==",
       "requires": {
         "@babel/runtime": "^7.12.1"
       },
@@ -4379,6 +4400,21 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "optional": true
+    },
+    "not": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/not/-/not-0.1.0.tgz",
+      "integrity": "sha1-yWkcF0bFXc++VMvYvU/wQbwrUZ0=",
+      "dev": true
+    },
+    "nth-check": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.0.tgz",
+      "integrity": "sha512-i4sc/Kj8htBrAiH1viZ0TgU8Y5XqCaV/FziYK6TBczxmeKm3AEFWqqF3195yKudrarqy7Zu80Ra5dobFjn9X/Q==",
+      "dev": true,
+      "requires": {
+        "boolbase": "^1.0.0"
+      }
     },
     "object-copy": {
       "version": "0.1.0",
@@ -5878,6 +5914,19 @@
       "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
       "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==",
       "dev": true
+    },
+    "unist-util-select": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/unist-util-select/-/unist-util-select-3.0.4.tgz",
+      "integrity": "sha512-xf1zCu4okgPqGLdhCDpRnjwBNyv3EqjiXRUbz2SdK1+qnLMB7uXXajfzuBvvbHoQ+JLyp4AEbFCGndmc6S72sw==",
+      "dev": true,
+      "requires": {
+        "css-selector-parser": "^1.0.0",
+        "not": "^0.1.0",
+        "nth-check": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "zwitch": "^1.0.0"
+      }
     },
     "unist-util-stringify-position": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remark-wiki-link",
   "description": "Parse and render wiki-style links",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "remark",
     "remark-plugin",
@@ -28,7 +28,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.4",
     "mdast-util-wiki-link": "0.0.1",
-    "micromark-extension-wiki-link": "^0.0.3"
+    "micromark-extension-wiki-link": "0.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",
@@ -44,6 +44,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
+    "mdast-util-from-markdown": "^0.8.4",
     "mocha": "^6.2.3",
     "rehype-stringify": "^8.0.0",
     "remark-parse": "^9.0.0",
@@ -51,6 +52,7 @@
     "remark-stringify": "^9.0.0",
     "rollup": "^2.32.0",
     "unified": "^9.2.0",
+    "unist-util-select": "^3.0.4",
     "unist-util-visit": "^2.0.3"
   }
 }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -4,6 +4,7 @@ const assert = require('assert')
 const unified = require('unified')
 const markdown = require('remark-parse')
 const visit = require('unist-util-visit')
+const select = require('unist-util-select')
 const remark2markdown = require('remark-stringify')
 
 describe('remark-wiki-link', () => {
@@ -177,6 +178,74 @@ describe('remark-wiki-link', () => {
       visit(ast, 'wikiLink', (node) => {
         assert.equal(node.data.hProperties.className, 'wiki_link')
       })
+    })
+  })
+
+  context('open wiki links', () => {
+    it('handles open wiki links', () => {
+      const processor = unified()
+        .use(markdown)
+        .use(wikiLinkPlugin, {
+          permalinks: []
+        })
+
+      var ast = processor.parse('t[[\nt')
+      ast = processor.runSync(ast)
+
+      assert.ok(!select.select('wikiLink', ast))
+    })
+
+    it('handles open wiki links at end of file', () => {
+      const processor = unified()
+        .use(markdown)
+        .use(wikiLinkPlugin, {
+          permalinks: []
+        })
+
+      var ast = processor.parse('t [[')
+      ast = processor.runSync(ast)
+
+      assert.ok(!select.select('wikiLink', ast))
+    })
+
+    it('handles open wiki links with partial data', () => {
+      const processor = unified()
+        .use(markdown)
+        .use(wikiLinkPlugin, {
+          permalinks: []
+        })
+
+      var ast = processor.parse('t [[tt\nt')
+      ast = processor.runSync(ast)
+
+      assert.ok(!select.select('wikiLink', ast))
+    })
+
+    it('handles open wiki links with partial alias divider', () => {
+      const processor = unified()
+        .use(markdown)
+        .use(wikiLinkPlugin, {
+          aliasDivider: '::',
+          permalinks: []
+        })
+
+      var ast = processor.parse('[[t::\n')
+      ast = processor.runSync(ast)
+
+      assert.ok(!select.select('wikiLink', ast))
+    })
+
+    it('handles open wiki links with partial alias', () => {
+      const processor = unified()
+        .use(markdown)
+        .use(wikiLinkPlugin, {
+          permalinks: []
+        })
+
+      var ast = processor.parse('[[t:\n')
+      ast = processor.runSync(ast)
+
+      assert.ok(!select.select('wikiLink', ast))
     })
   })
 })


### PR DESCRIPTION
We missed a few cases for the fix in
https://github.com/landakram/micromark-extension-wiki-link/pull/4. These were fixed
in https://github.com/landakram/micromark-extension-wiki-link/pull/5.

Update dependencies to bring in the fix and tests for all partial wiki link cases here too.

Closes https://github.com/landakram/remark-wiki-link/issues/9