### PR TITLE
Use a default export instead of named

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Looking for lower level packages? Check out [mdast-util-wiki-link](https://githu
 ```javascript
 const unified = require('unified')
 const markdown = require('remark-parse')
-const { wikiLinkPlugin } = require('remark-wiki-link');
+const wikiLinkPlugin = require('remark-wiki-link');
 
 let processor = unified()
     .use(markdown, { gfm: true })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "remark-wiki-link",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remark-wiki-link",
   "description": "Parse and render wiki-style links",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "keywords": [
     "remark",
     "remark-plugin",

--- a/src/index.js
+++ b/src/index.js
@@ -29,4 +29,5 @@ function wikiLinkPlugin (opts = {}) {
   add('toMarkdownExtensions', toMarkdown(opts))
 }
 
+wikiLinkPlugin.wikiLinkPlugin = wikiLinkPlugin
 export default wikiLinkPlugin

--- a/src/index.js
+++ b/src/index.js
@@ -29,4 +29,4 @@ function wikiLinkPlugin (opts = {}) {
   add('toMarkdownExtensions', toMarkdown(opts))
 }
 
-export { wikiLinkPlugin }
+export default wikiLinkPlugin

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,4 +1,5 @@
-const { wikiLinkPlugin } = require('..')
+const wikiLinkPlugin = require('..')
+const { wikiLinkPlugin: namedWikiLinkPlugin } = require('..')
 
 const assert = require('assert')
 const unified = require('unified')
@@ -247,5 +248,9 @@ describe('remark-wiki-link', () => {
 
       assert.ok(!select.select('wikiLink', ast))
     })
+  })
+
+  it('exports the plugin with named exports', () => {
+    assert.equal(wikiLinkPlugin, namedWikiLinkPlugin)
   })
 })


### PR DESCRIPTION
This PR changes `src/index.js` to use a default export instead of a named export. As noted in #12 this seems to be common behaviour for remark plugins, and I personally found this change was necessary to use this package with `nuxt-content` (https://github.com/landakram/remark-wiki-link/issues/12#issuecomment-813043538), which assumes that the given plugin uses default exports.

I notice `rollup` doesn't fail but gives this warning when building. The option it suggests suppresses the warning, but I'm not sure whether this is the best way to address this issue.

```
src/index.js → dist/index.cjs.js, dist/index.esm.js...
(!) Entry module "src\index.js" is implicitly using "default" export mode, which means for CommonJS output that its default export is assigned to "module.exports". For many 
tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set "output.exports" to either "auto" or "default", otherwise you might want to consider changing the signature of "src\index.js" to use named exports only.
https://rollupjs.org/guide/en/#outputexports
src\index.js
created dist/index.cjs.js, dist/index.esm.js in 30ms
```

I realise this is a breaking change, as any import lines will change. I've left the `package.json` version as-is to be bumped after merge.