### PR TITLE
Update mdast-util-wiki-link to 0.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,12 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "remark-wiki-link",
       "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.4.4",
-        "mdast-util-wiki-link": "^0.0.2",
+        "mdast-util-wiki-link": "^0.1.1",
         "micromark-extension-wiki-link": "^0.0.4"
       },
       "devDependencies": {
@@ -4676,9 +4677,9 @@
       }
     },
     "node_modules/mdast-util-wiki-link": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-wiki-link/-/mdast-util-wiki-link-0.0.2.tgz",
-      "integrity": "sha512-lSsR10/dPuYIxzjGZIGA4oYzsnEnqcsD6DTXL0pqdbBzNB9teKVZB2aIzZcUsdg31v/NoHOstkVwzbN6VrQLtw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-wiki-link/-/mdast-util-wiki-link-0.1.1.tgz",
+      "integrity": "sha512-IQb2Ovoym4R/Q+aRO1sCYSpCvVRhis+Y43JgXwqpY1a6lTCAv70zBSLJ269ciXadC5YyEuUf0GCGA0s9UbZRGg==",
       "dependencies": {
         "@babel/runtime": "^7.12.1",
         "mdast-util-to-markdown": "^0.6.5"
@@ -10951,9 +10952,9 @@
       "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
     },
     "mdast-util-wiki-link": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-wiki-link/-/mdast-util-wiki-link-0.0.2.tgz",
-      "integrity": "sha512-lSsR10/dPuYIxzjGZIGA4oYzsnEnqcsD6DTXL0pqdbBzNB9teKVZB2aIzZcUsdg31v/NoHOstkVwzbN6VrQLtw==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-wiki-link/-/mdast-util-wiki-link-0.1.1.tgz",
+      "integrity": "sha512-IQb2Ovoym4R/Q+aRO1sCYSpCvVRhis+Y43JgXwqpY1a6lTCAv70zBSLJ269ciXadC5YyEuUf0GCGA0s9UbZRGg==",
       "requires": {
         "@babel/runtime": "^7.12.1",
         "mdast-util-to-markdown": "^0.6.5"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",
-    "mdast-util-wiki-link": "^0.0.2",
+    "mdast-util-wiki-link": "^0.1.1",
     "micromark-extension-wiki-link": "^0.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
I encountered the issues described in https://github.com/landakram/mdast-util-wiki-link/issues/6 and realized that it's because although the problem has been fixed in mdast-util-wiki-link@0.1.1, this repo specifies a semver `^0.0.2` for that dependency, which won't use the latest version. Updating the package solved the problems I was observing; the repo's tests pass as expected.